### PR TITLE
Add Automatic-Module-Name to support JPMS

### DIFF
--- a/code-assert/pom.xml
+++ b/code-assert/pom.xml
@@ -19,6 +19,7 @@
         <kotlin.version>1.3.71</kotlin.version>
         <detekt.version>1.9.1</detekt.version>
         <ktlint.version>0.36.0</ktlint.version>
+        <maven-jar.version>3.2.0</maven-jar.version>
     </properties>
 
     <build>
@@ -79,6 +80,18 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven-jar.version}</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>guru.nidi.codeassert</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
To permit modularized projects to access non-modular JARs, Java 9+ allows importing JAR files without a `module-info.class` as "automatic modules".  

Per the [ModuleFinder](https://docs.oracle.com/javase/9/docs/api/java/lang/module/ModuleFinder.html#of-java.nio.file.Path...-) javadoc:

> If the JAR file has the attribute "Automatic-Module-Name" in its main manifest then its value is the module name. The module name is otherwise derived from the name of the JAR file.

The automatic name generation without such an entry extracts the version information and then substitutes a dot for all non-alphanumeric characters.  In the case of `code-assert-0.9.11.jar` the resulting module name is `code.assert` which is illegal due to the reserved word `assert`, making this project unusable as a module.

This commit leverages the `maven-jar-plugin` to generate a manifest file including a legal `Automatic-Module-Name`.