### PR TITLE
additional language: 'adoc' (asciidoc, antora)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .idea/
 target/
 *.iml
+
+# Eclipse
+.settings
+.classpath
+.project

--- a/code-assert-core/src/main/java/guru/nidi/codeassert/config/Language.java
+++ b/code-assert-core/src/main/java/guru/nidi/codeassert/config/Language.java
@@ -23,7 +23,9 @@ public enum Language {
     JAVA("java", asList(".java")),
     KOTLIN("kotlin", asList(".kt", ".kts")),
     SCALA("scala", asList(".scala")),
-    GROOVY("groovy", asList(".groovy", ".gvy", ".gy", ".gsh"));
+    GROOVY("groovy", asList(".groovy", ".gvy", ".gy", ".gsh")),
+    ADOC("adoc", asList(".adoc")),
+    ;
 
     final String path;
     final List<String> suffices;


### PR DESCRIPTION
Having to add languages that way is a bit unfortunate. I understand if this PR gets rejected, because `adoc` simply is not a programming language technically speaking.

Instead what would make this library even greater would be an option for consumers of the library to add their own languages. What comes to mind is converting the existing `Language` enum to an interface (see below). But as I fiddled a bit with the sources, even though such a change can be easily done in a couple of hours, it would break backward compatibility.

Anyway thumbs up on the library!

```java
package guru.nidi.codeassert.config;

import java.util.List;

import static java.util.Arrays.asList;

public interface Language {
    
    String getPath();
    List<String> getSuffices();
    
    public enum PopularLanguage implements Language  {
        JAVA("java", asList(".java")),
        KOTLIN("kotlin", asList(".kt", ".kts")),
        SCALA("scala", asList(".scala")),
        GROOVY("groovy", asList(".groovy", ".gvy", ".gy", ".gsh"));

        final String path;
        final List<String> suffices;

        PopularLanguage(String path, List<String> suffices) {
            this.path = path;
            this.suffices = suffices;
        }
        
        @Override
        public String getPath() {
            return path;
        }
        
        @Override
        public List<String> getSuffices() {
            return suffices;
        }

        public static PopularLanguage byFilename(String filename) {
            final String suffix = filename.substring(filename.lastIndexOf('.'));
            for (final PopularLanguage lang : values()) {
                if (lang.suffices.contains(suffix)) {
                    return lang;
                }
            }
            return null;
        }

    }
    
    
}
```